### PR TITLE
Fix some links routes in contributors page

### DIFF
--- a/src/app/contributors/page.tsx
+++ b/src/app/contributors/page.tsx
@@ -45,7 +45,7 @@ export default async function Page() {
                 <main>
                     <div className="mt-16 pt-8 border-t border-gray-800 flex justify-between items-center">
                         <Link
-                            href="/contributors"
+                            href="/hacks"
                             className="text-sm text-gray-400 hover:text-gray-300 inline-flex items-center"
                         >
                             <svg

--- a/src/app/contributors/page.tsx
+++ b/src/app/contributors/page.tsx
@@ -20,7 +20,7 @@ export default async function Page() {
                 <nav className="mb-16 pt-8">
                     <ul className="flex space-x-6 text-sm">
                         <li>
-                            <Link href="/public" className="hover:text-gray-400">
+                            <Link href="/" className="hover:text-gray-400">
                                 Home
                             </Link>
                         </li>


### PR DESCRIPTION
Home page link in Navbar routes to '/public' and "Back to Hacks" link routes to '/contributors'.